### PR TITLE
Update Go to v1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,25 @@
 module antrea.io/ofnet
 
-go 1.15
+go 1.19
 
 require (
 	antrea.io/libOpenflow v0.10.1
 	github.com/Microsoft/go-winio v0.4.14
-	github.com/cenkalti/hub v1.0.1-0.20140529221144-7be60e186e66 // indirect
-	github.com/cenkalti/rpc2 v0.0.0-20140912135055-44d0d95e4f52 // indirect
 	github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358
-	github.com/kr/pretty v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/streamrail/concurrent-map v0.0.0-20160803124810-238fe79560e1
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/cenkalti/hub v1.0.1-0.20140529221144-7be60e186e66 // indirect
+	github.com/cenkalti/rpc2 v0.0.0-20140912135055-44d0d95e4f52 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	k8s.io/klog/v2 v2.60.1 // indirect
 )


### PR DESCRIPTION
Github runner OSes set v1.20.x as default on April 3. The typecheck started failing after that. Update Go version to the same version as antrea to fix it.