### PR TITLE
Add release branches to workflow branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     branches:
     - main
+    - release-*
   push:
     branches:
     - main
+    - release-*
 
 jobs:
   # test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths:
       - 'VERSION'
 


### PR DESCRIPTION
To support patch tag of previous releases, make the workflow run on release branches too. Otherwise it's hard to pick up bug fixes in ofnet for previous Antrea releases once ofnet introduces a breaking change and updates the minor number of the version.