### PR TITLE
[Renovate] Disable indirect gomod dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,16 +28,21 @@
   },
 
   packageRules: [
+    // Disable indirect go dependencies updates, resource: https://github.com/renovatebot/renovate/discussions/35225#discussioncomment-13666269
+    {
+      matchManagers: ["gomod"],
+      matchDepTypes: ["indirect"],
+      enabled: false,
+    },
+
     {
       matchManagers: ["gomod"],
       addLabels: ["go"],
-      enabled: true,
     },
 
     {
       matchManagers: ["github-actions"],
       addLabels: ["github_actions"],
-      enabled: true,
     },
   ],
 }


### PR DESCRIPTION
Changes include:

- Remove redundant `enabled: true` declarations from Renovate configuration for consistent configuration.

- Modifications to the Renovate config file to turn off PRs generated for indirect Go dependencies.